### PR TITLE
Create a TOC for Jekyll rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 # O'Reilly Awesome List
 
-* TOC
+- TOC
 {:toc}
 
 ## Command Line


### PR DESCRIPTION
Adds a table of contents to the Pages version of the site using the Jekyll `{:toc}` tag.